### PR TITLE
Support lint for sub-package usage

### DIFF
--- a/faillint/faillint.go
+++ b/faillint/faillint.go
@@ -57,6 +57,18 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				continue
 			}
 
+			if !exact {
+				importPath, err := strconv.Unquote(imp.Path.Value)
+				if err != nil {
+					continue
+				}
+				// If user has explicitly specified this path, skip this non-exact match,
+				// and leave to be handled in the exact path.
+				if _, ok := suggestions[importPath]; ok {
+					continue
+				}
+			}
+
 			var msg string
 			if exact {
 				msg = fmt.Sprintf("package %q shouldn't be imported", path)

--- a/faillint/faillint_test.go
+++ b/faillint/faillint_test.go
@@ -34,6 +34,10 @@ func Test(t *testing.T) {
 			name:  "e",
 			paths: "errors=github.com/pkg/errors,golang.org/x/net/context=context",
 		},
+		{
+			name:  "f",
+			paths: "golang.org/x/net",
+		},
 	}
 	for _, ts := range tests {
 		ts := ts

--- a/faillint/faillint_test.go
+++ b/faillint/faillint_test.go
@@ -38,6 +38,10 @@ func Test(t *testing.T) {
 			name:  "f",
 			paths: "golang.org/x/net",
 		},
+		{
+			name:  "g",
+			paths: "golang.org/x/net=net,golang.org/x/net/context=context",
+		},
 	}
 	for _, ts := range tests {
 		ts := ts

--- a/faillint/testdata/src/f/f.go
+++ b/faillint/testdata/src/f/f.go
@@ -1,0 +1,8 @@
+package e
+
+import (
+	"golang.org/x/net/context" // want `sub-package of "golang.org/x/net" shouldn't be imported`
+)
+
+func foo(ctx context.Context) {
+}

--- a/faillint/testdata/src/g/g.go
+++ b/faillint/testdata/src/g/g.go
@@ -1,0 +1,8 @@
+package e
+
+import (
+	"golang.org/x/net/context" // want `package "golang.org/x/net/context" shouldn't be imported, suggested: "context"`
+)
+
+func foo(ctx context.Context) {
+}


### PR DESCRIPTION
The given NOT to import package will be linted not only for itself, but also for its sub-packages. The lint message will also reflect this.

Additionally we should allow user to pass in root package path and sub package path and prefer the exact matching path if any. E.g. when pass in *a=x* and *a/b=y*, then we should lint the import path of *a/b* using the *a/b=y* suggestion (instead of *a=x*), this allows package author to split a mono package into several independent packages.

Another potential issue is that user might passing, e.g., *a*, *a/b*, and the code actually only import *a/b/c*. For now I didn't considered this case yet since I want to see whether I'm in the correct direction first, before diving into too detail.