### PR TITLE
Add -exclude flag

### DIFF
--- a/faillint/faillint_test.go
+++ b/faillint/faillint_test.go
@@ -184,9 +184,10 @@ func TestRun(t *testing.T) {
 	testdata := analysistest.TestData()
 
 	for _, tcase := range []struct {
-		name  string
-		dir   string
-		paths string
+		name    string
+		dir     string
+		paths   string
+		exclude string
 
 		ignoreTestFiles bool
 	}{
@@ -313,12 +314,19 @@ func TestRun(t *testing.T) {
 			dir:   "q",
 			paths: "errors",
 		},
+		{
+			name:    "excluding subpackage while still scanning parent package",
+			dir:     "r/...",
+			paths:   "errors,fmt",
+			exclude: "r/subdir/...",
+		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {
 			f := NewAnalyzer()
-			f.Flags.Set("paths", tcase.paths)
+			_ = f.Flags.Set("paths", tcase.paths)
+			_ = f.Flags.Set("exclude", tcase.exclude)
 			if tcase.ignoreTestFiles {
-				f.Flags.Set("ignore-tests", "true")
+				_ = f.Flags.Set("ignore-tests", "true")
 			}
 
 			// No assertion on result is required as 'analysistest' is for that.

--- a/faillint/testdata/src/r/r.go
+++ b/faillint/testdata/src/r/r.go
@@ -1,0 +1,7 @@
+package r
+
+import "fmt" // want `package "fmt" shouldn't be imported`
+
+func foo() error {
+	return fmt.Errorf("")
+}

--- a/faillint/testdata/src/r/subdir/file_in_subdir.go
+++ b/faillint/testdata/src/r/subdir/file_in_subdir.go
@@ -1,0 +1,7 @@
+package subdir
+
+import "errors"
+
+func foo() error {
+	return errors.New("bar")
+}


### PR DESCRIPTION
The flag takes the same format as the -paths flag. Any package matched
by any of the paths in the -exclude flag will be ignored in the scan.

Resolves #25 