### PR TITLE
failint: add ability to lint only tests

### DIFF
--- a/faillint/faillint_test.go
+++ b/faillint/faillint_test.go
@@ -188,8 +188,21 @@ func TestRun(t *testing.T) {
 		dir   string
 		paths string
 
-		ignoreTestFiles bool
+		ignoreTestFiles   bool
+		onlyTestFunctions bool
 	}{
+		{
+			name:              "sleep in a function which is not a test",
+			dir:               "sleepintest",
+			paths:             "time.{Sleep}",
+			onlyTestFunctions: true,
+		},
+		{
+			name:              "sleep in a function which is not a test",
+			dir:               "sleepintest_err",
+			paths:             "time.{Sleep}",
+			onlyTestFunctions: true,
+		},
 		{
 			name:  "unwanted errors package present",
 			dir:   "a",
@@ -319,6 +332,9 @@ func TestRun(t *testing.T) {
 			f.Flags.Set("paths", tcase.paths)
 			if tcase.ignoreTestFiles {
 				f.Flags.Set("ignore-tests", "true")
+			}
+			if tcase.onlyTestFunctions {
+				f.Flags.Set("only-tests", "true")
 			}
 
 			// No assertion on result is required as 'analysistest' is for that.

--- a/faillint/testdata/src/sleepintest/sleepintest_test.go
+++ b/faillint/testdata/src/sleepintest/sleepintest_test.go
@@ -1,0 +1,9 @@
+package sleepintest
+
+import (
+	"time"
+)
+
+func fooTest() {
+	time.Sleep(1 * time.Second)
+}

--- a/faillint/testdata/src/sleepintest_err/sleepintest_test.go
+++ b/faillint/testdata/src/sleepintest_err/sleepintest_test.go
@@ -1,0 +1,10 @@
+package sleepintest
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFoo(t *testing.T) {
+	time.Sleep(1 * time.Second) // want `declaration "Sleep" from package "time" shouldn't be used`
+}


### PR DESCRIPTION
Add the ability to lint only testing functions. This is useful to prevent hardcoded sleeps in tests leading to flaky tests.

I have never worked with the AST package in Go so this requires extra carefulness.

Solves https://github.com/fatih/faillint/issues/30.