### PR TITLE
Bump go tools version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,13 @@
 module github.com/fatih/faillint
 
-go 1.18
+go 1.22.0
 
 require (
 	dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363
-	golang.org/x/tools v0.19.0
+	golang.org/x/tools v0.29.0
 )
 
-require golang.org/x/mod v0.16.0 // indirect
+require (
+	golang.org/x/mod v0.22.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
 dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363 h1:o4lAkfETerCnr1kF9/qwkwjICnU+YLHNDCM8h2xj7as=
 dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363/go.mod h1:WG7q7swWsS2f9PYpt5DoEP/EBYWx8We5UoRltn9vJl8=
-golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
-golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=
-golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
+golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.29.0 h1:Xx0h3TtM9rzQpQuR4dKLrdglAmCEN5Oi+P74JdhdzXE=
+golang.org/x/tools v0.29.0/go.mod h1:KMQVMRsVxU6nHCFXrBPhDB8XncLNLM0lIy/F14RP588=


### PR DESCRIPTION
Trying to bump our Go version from Go 1.23.x to 1.24.0 has resulted in errors in `faillint`

An example error is:
```
faillint -paths "sync/atomic=go.uber.org/atomic" ./pkg/scheduler/limits/...
faillint: internal error: package "math" without types was imported from "github.com/grafana/loki/v3/pkg/scheduler/limits"
```

The above was working before bumping the Go version.

What I am proposing is bumping the underlying `golang.org/x/tools` to a more recent version. I did not bump to the latest, as that seems to force a dependence on Go 1.24.  Going to 0.29 works on Go 1.22, which is 2 releases old.

After doing this and trying it locally, the `faillint` checks seem to pass.